### PR TITLE
fix: 修复 _merge_all_logs 在 Windows 上的文件顺序差异

### DIFF
--- a/src/command_control_extension_tcp.py
+++ b/src/command_control_extension_tcp.py
@@ -39,7 +39,7 @@ def _merge_log_dicts(base_data, extra_data):
 
 def _merge_all_logs(log_dir, merged_filename='merged_logs.json'):
     merged_data = {}
-    for filename in os.listdir(log_dir):
+    for filename in sorted(os.listdir(log_dir)):
         if not filename.endswith('.json') or filename == merged_filename:
             continue
         file_path = os.path.join(log_dir, filename)

--- a/test/test_command_handlers.py
+++ b/test/test_command_handlers.py
@@ -107,5 +107,5 @@ def test_command_done_merges_transferred_logs_into_one_file(server, tmp_path, mo
     merged_file = logs_dir / "merged_logs.json"
     assert merged_file.exists()
     merged = json.loads(merged_file.read_text(encoding="utf-8"))
-    assert merged["cmd1"][0] == {"error": "none"}
-    assert merged["cmd1"][1] == {"output": "ok"}
+    assert merged["cmd1"][0] == {"output": "ok"}
+    assert merged["cmd1"][1] == {"error": "none"}


### PR DESCRIPTION
@F18-Ray 