### PR TITLE
feat: udp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ test/build/
 test/venv/
 test/src/
 */__pycache__/
+.coverage
 
 # CLion
 #  JetBrains specific template is maintained in a separate JetBrains.gitignore that can

--- a/docs/Network_APIs/TCP_Client_APIs.rst
+++ b/docs/Network_APIs/TCP_Client_APIs.rst
@@ -317,4 +317,5 @@ Sending a file from the client console:
 See Also
 --------
 
-The server-side companion documentation: :doc:`TCP_Server_APIs`.
+- :doc:`TCP_Server_APIs` — TCP server.
+- :doc:`UDP_APIs` — UDP endpoint.

--- a/docs/Network_APIs/TCP_Server_APIs.rst
+++ b/docs/Network_APIs/TCP_Server_APIs.rst
@@ -735,6 +735,5 @@ are following as:
 See Also
 --------
 
-For more informations about the client APIs, 
-please visit the client API documentation, at 
-:doc:`TCP_Client_APIs`.
+- :doc:`TCP_Client_APIs` — TCP client.
+- :doc:`UDP_APIs` — UDP endpoint.

--- a/docs/Network_APIs/UDP_APIs.rst
+++ b/docs/Network_APIs/UDP_APIs.rst
@@ -1,114 +1,111 @@
-UDP API
-=======
+The UDP API
+===========
 
-A lightweight UDP endpoint for service discovery, broadcast, and
-simple request-response communication.
+UDP setup API
+-------------
+
+The UDP Setup API is used to create a UDP endpoint. The UDP
+endpoint in the protocol is usually used for service discovery,
+broadcast, and simple request-response communication.
 
 .. code-block:: python
 
     class UDP:
-        def __init__(self, host="0.0.0.0", port=0):
+        def __init__(self, host="0.0.0.0", port=0) -> None:
             ...
 
-The socket is created and bound in the constructor.
-Both ``SO_REUSEADDR`` and ``SO_BROADCAST`` are set automatically.
+The UDP endpoint is defined in the ``UDP`` class. The socket is
+created and bound in the constructor. Both ``SO_REUSEADDR`` and
+``SO_BROADCAST`` are set automatically.
 
-Parameters
-----------
+Parameters of the ``__init__`` method are as follows:
 
-- ``host``: Interface to bind to. Default ``"0.0.0.0"`` (all interfaces).
-- ``port``: Port to bind to. ``0`` lets the OS choose.
+- ``host``: The interface to bind to. Default is ``"0.0.0.0"``
+  (all interfaces).
+- ``port``: The port to bind to. Default is ``0``, which lets
+  the OS choose an available port dynamically.
 
-Properties
-----------
+Every parameter has a default value:
+
+- ``host``: Default is ``"0.0.0.0"``
+- ``port``: Default is ``0``
+
+*Note: The public API of the UDP endpoint is based on IPv4 form.*
+
+UDP endpoint API
+----------------
+
+The public methods available on a ``UDP`` instance are:
+
+.. code-block:: python
+
+    def send(self, data: bytes, addr: tuple) -> None:
+        ...
+    def broadcast(self, data: bytes, port: int) -> None:
+        ...
+    def listen(self, handler) -> None:
+        ...
+    def close(self) -> None:
+        ...
+
+``send``
+    Sends a datagram to the specified address. The ``addr``
+    parameter should be a ``(host, port)`` tuple. This method
+    will raise ``OSError`` on network failure.
+
+``broadcast``
+    Sends a datagram to the subnet broadcast address on the
+    given port. This is implemented by calling ``send`` with
+    the address ``("255.255.255.255", port)``.
+
+``listen``
+    Starts a daemon thread that receives incoming datagrams.
+    The ``handler`` is a callable ``handler(data, addr)`` that
+    is invoked for each datagram received. Handler exceptions
+    are logged via the ``logging`` module rather than propagated,
+    so a faulty handler does not terminate the receive loop.
+    This method is idempotent: calling it while the receive
+    thread is already running does nothing.
+
+``close``
+    Signals the receive loop to exit and closes the underlying
+    socket. The ``_closed`` flag is set to ``True`` and the
+    socket's ``close()`` method is called to interrupt any
+    blocking ``recvfrom`` call. This method is idempotent:
+    calling it multiple times does not raise an error.
+
+*Note: When ``listen`` is called after ``close``, a*
+*``RuntimeError`` *with the message "endpoint is closed" is*
+*raised, because the underlying socket is no longer available.*
 
 .. code-block:: python
 
     @property
-    def port(self) -> int
+    def port(self) -> int:
+        ...
     @property
-    def local_addr(self) -> tuple[str, int]
+    def local_addr(self) -> tuple[str, int]:
+        ...
 
-Methods
--------
+``port``
+    Returns the port number the socket is bound to. Useful when
+    ``port=0`` was passed to the constructor and the OS assigned
+    a dynamic port.
+
+``local_addr``
+    Returns the full ``(host, port)`` tuple that the socket is
+    bound to.
+
+The ``UDP`` class also supports the context manager protocol,
+so it can be used in a ``with`` statement:
 
 .. code-block:: python
 
-    def send(self, data: bytes, addr: tuple) -> None
-    def broadcast(self, data: bytes, port: int) -> None
-    def listen(self, handler) -> None
-    def close(self) -> None
+    with UDP("127.0.0.1", 65000) as u:
+        ...
 
-``send(data, addr)``
-    Send a datagram. Raises ``OSError`` on network failure.
-
-``broadcast(data, port)``
-    Broadcast a datagram to the subnet.
-
-``listen(handler)``
-    Start receiving datagrams in a daemon thread. Calls
-    ``handler(data, addr)`` for each incoming datagram until
-    ``close()`` is called. Handler exceptions are logged, not
-    raised. Idempotent.
-
-``close()``
-    Signal the receive loop to exit and close the socket. Idempotent.
-
-``UDP`` supports the ``with`` statement: ``with UDP(...) as u: ...``
-
-Usage patterns
---------------
-
-Echo server::
-
-    from src.connect_udp import UDP
-
-    s = UDP("127.0.0.1", 65000)
-    s.listen(lambda data, addr: s.send(data, addr))
-    # Ctrl+C to exit
-
-Client with reply (using raw socket for synchronous receive)::
-
-    import socket
-    from src.connect_udp import UDP
-
-    srv = UDP("127.0.0.1", 65000)
-    srv.listen(lambda data, addr: srv.send(b"pong", addr))
-
-    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    sock.bind(("127.0.0.1", 0))
-    sock.sendto(b"/ping", ("127.0.0.1", 65000))
-    sock.settimeout(2)
-    try:
-        data, addr = sock.recvfrom(65535)
-        print(data.decode())  # "pong"
-    except TimeoutError:
-        print("no reply")
-    finally:
-        sock.close()
-    srv.close()
-
-Broadcast discovery::
-
-    from src.connect_udp import UDP
-
-    srv = UDP("0.0.0.0", 65000)
-    srv.listen(lambda data, addr: print(f"recv from {addr}: {data.decode()}"))
-
-    c = UDP()
-    c.broadcast(b"/who", 65000)
-    c.close()
-    srv.close()
-
-Blocking mode (user-managed thread)::
-
-    import threading
-    from src.connect_udp import UDP
-
-    s = UDP("127.0.0.1", 65000)
-    s.listen(lambda d, a: print(d))
-    # thread runs until close()
-    s.close()
+*Note: The context manager calls ``close`` automatically when*
+*the ``with`` block exits.*
 
 Key differences from TCP
 ------------------------

--- a/docs/Network_APIs/UDP_APIs.rst
+++ b/docs/Network_APIs/UDP_APIs.rst
@@ -1,0 +1,127 @@
+UDP API
+=======
+
+A lightweight UDP endpoint for service discovery, broadcast, and
+simple request-response communication.
+
+.. code-block:: python
+
+    class UDP:
+        def __init__(self, host="0.0.0.0", port=0):
+            ...
+
+The socket is created and bound in the constructor.
+Both ``SO_REUSEADDR`` and ``SO_BROADCAST`` are set automatically.
+
+Parameters
+----------
+
+- ``host``: Interface to bind to. Default ``"0.0.0.0"`` (all interfaces).
+- ``port``: Port to bind to. ``0`` lets the OS choose.
+
+Properties
+----------
+
+.. code-block:: python
+
+    @property
+    def port(self) -> int
+    @property
+    def local_addr(self) -> tuple[str, int]
+
+Methods
+-------
+
+.. code-block:: python
+
+    def send(self, data: bytes, addr: tuple) -> None
+    def broadcast(self, data: bytes, port: int) -> None
+    def listen(self, handler) -> None
+    def close(self) -> None
+
+``send(data, addr)``
+    Send a datagram. Raises ``OSError`` on network failure.
+
+``broadcast(data, port)``
+    Broadcast a datagram to the subnet.
+
+``listen(handler)``
+    Start receiving datagrams in a daemon thread. Calls
+    ``handler(data, addr)`` for each incoming datagram until
+    ``close()`` is called. Handler exceptions are logged, not
+    raised. Idempotent.
+
+``close()``
+    Signal the receive loop to exit and close the socket. Idempotent.
+
+``UDP`` supports the ``with`` statement: ``with UDP(...) as u: ...``
+
+Usage patterns
+--------------
+
+Echo server::
+
+    from src.connect_udp import UDP
+
+    s = UDP("127.0.0.1", 65000)
+    s.listen(lambda data, addr: s.send(data, addr))
+    # Ctrl+C to exit
+
+Client with reply (using raw socket for synchronous receive)::
+
+    import socket
+    from src.connect_udp import UDP
+
+    srv = UDP("127.0.0.1", 65000)
+    srv.listen(lambda data, addr: srv.send(b"pong", addr))
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", 0))
+    sock.sendto(b"/ping", ("127.0.0.1", 65000))
+    sock.settimeout(2)
+    try:
+        data, addr = sock.recvfrom(65535)
+        print(data.decode())  # "pong"
+    except TimeoutError:
+        print("no reply")
+    finally:
+        sock.close()
+    srv.close()
+
+Broadcast discovery::
+
+    from src.connect_udp import UDP
+
+    srv = UDP("0.0.0.0", 65000)
+    srv.listen(lambda data, addr: print(f"recv from {addr}: {data.decode()}"))
+
+    c = UDP()
+    c.broadcast(b"/who", 65000)
+    c.close()
+    srv.close()
+
+Blocking mode (user-managed thread)::
+
+    import threading
+    from src.connect_udp import UDP
+
+    s = UDP("127.0.0.1", 65000)
+    s.listen(lambda d, a: print(d))
+    # thread runs until close()
+    s.close()
+
+Key differences from TCP
+------------------------
+
+- **No file transfer**. UDP is unreliable; use TCP classes for file transfers.
+- **No connection tracking**. Each datagram carries its own source address.
+- **No port allocation system**. UDP does not need ephemeral ports for
+  data connections.
+- **Broadcast**. UDP's standout feature — one send reaches all listeners
+  on the subnet.
+
+See Also
+--------
+
+- :doc:`TCP_Server_APIs` — TCP server.
+- :doc:`TCP_Client_APIs` — TCP client.

--- a/docs/Network_APIs/UDP_APIs.rst
+++ b/docs/Network_APIs/UDP_APIs.rst
@@ -49,14 +49,15 @@ The public methods available on a ``UDP`` instance are:
         ...
 
 ``send``
-    Sends a datagram to the specified address. The ``addr``
-    parameter should be a ``(host, port)`` tuple. This method
-    will raise ``OSError`` on network failure.
+    Wraps ``socket.sendto(data, addr)``. The ``addr`` parameter
+    should be a ``(host, port)`` tuple. Raises ``OSError`` if
+    the socket is closed or the address is invalid. Note that
+    a successful return does not confirm delivery.
 
 ``broadcast``
-    Sends a datagram to the subnet broadcast address on the
-    given port. This is implemented by calling ``send`` with
-    the address ``("255.255.255.255", port)``.
+    Sends a datagram to the limited broadcast address
+    ``255.255.255.255`` on the given port. This is implemented
+    by calling ``send`` with the address ``("255.255.255.255", port)``.
 
 ``listen``
     Starts a daemon thread that receives incoming datagrams.

--- a/src/connect_udp.py
+++ b/src/connect_udp.py
@@ -1,1 +1,66 @@
+import logging
 import socket
+import threading
+
+logger = logging.getLogger(__name__)
+
+MAX_DATAGRAM = 65535
+
+
+class UDP:
+    def __init__(self, host='0.0.0.0', port=0):
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_BROADCAST, 1)
+        self._socket.bind((host, port))
+        self._addr = self._socket.getsockname()
+        self._recv_thread = None
+        self._closed = False
+
+    @property
+    def local_addr(self):
+        return self._addr
+
+    @property
+    def port(self):
+        return self._addr[1]
+
+    def send(self, data, addr):
+        self._socket.sendto(data, addr)
+
+    def broadcast(self, data, port):
+        self.send(data, ('255.255.255.255', port))
+
+    def listen(self, handler):
+        if self._closed:
+            raise RuntimeError('endpoint is closed')
+        if self._recv_thread and self._recv_thread.is_alive():
+            return
+        self._recv_thread = threading.Thread(target=self._run, args=(handler,), daemon=True)
+        self._recv_thread.start()
+
+    def _run(self, handler):
+        self._socket.settimeout(0.1)
+        while True:
+            try:
+                data, addr = self._socket.recvfrom(MAX_DATAGRAM)
+            except TimeoutError:
+                continue
+            except OSError:
+                if self._closed:
+                    return
+                raise
+            try:
+                handler(data, addr)
+            except Exception:
+                logger.exception(f'handler error from {addr}')
+
+    def close(self):
+        self._closed = True
+        self._socket.close()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -10,6 +10,7 @@ if importlib.util.find_spec("src") is None:
 
 import src.command_control_extension_tcp as ctl
 from src.connect_tcp import TCP_Client_Base, TCP_Server_Base
+from src.connect_udp import UDP
 
 SERVER_PORT = 65001
 CLIENT_PORT = 65000
@@ -62,3 +63,24 @@ def server_client(monkeypatch):
             c.close()
         finally:
             s.stop()
+
+
+@pytest.fixture
+def udp_server():
+    """A UDP endpoint with a no-op callback, actively listening on a dynamic port."""
+    s = UDP("127.0.0.1", 0)
+    s.listen(lambda data, addr: None)
+    try:
+        yield s
+    finally:
+        s.close()
+
+
+@pytest.fixture
+def udp_client():
+    """A UDP client endpoint bound to a dynamic port, not listening."""
+    c = UDP("127.0.0.1", 0)
+    try:
+        yield c
+    finally:
+        c.close()

--- a/test/test_udp.py
+++ b/test/test_udp.py
@@ -1,0 +1,154 @@
+import socket
+import threading
+
+import pytest
+
+from src.connect_udp import UDP
+
+UDP_BROADCAST_PORT = 65030
+
+
+def test_udp_server_init(udp_server):
+    assert udp_server.port > 0
+
+
+def test_udp_client_init(udp_client):
+    assert udp_client.port > 0
+    host, port = udp_client.local_addr
+    assert host == "127.0.0.1"
+    assert port == udp_client.port
+
+
+def test_udp_create_and_close():
+    udp = UDP("127.0.0.1", 0)
+    assert udp._socket.fileno() >= 0
+    udp.close()
+    assert udp._socket.fileno() == -1
+
+
+def test_udp_send_and_reply():
+    server = UDP("127.0.0.1", 0)
+
+    def on_msg(data, addr):
+        if data.strip() == b"/ping":
+            server.send(b"pong", addr)
+
+    server.listen(on_msg)
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.bind(("127.0.0.1", 0))
+    try:
+        sock.sendto(b"/ping", ("127.0.0.1", server.port))
+        sock.settimeout(2)
+        data, addr = sock.recvfrom(65535)
+        assert data.strip() == b"pong"
+    finally:
+        sock.close()
+        server.close()
+
+
+def test_udp_broadcast():
+    received = threading.Event()
+
+    s1 = UDP("0.0.0.0", UDP_BROADCAST_PORT)
+    s1.listen(lambda data, addr: received.set())
+
+    c = UDP("0.0.0.0")
+    try:
+        c.broadcast(b"/probe", UDP_BROADCAST_PORT)
+        assert received.wait(timeout=2), "did not receive broadcast"
+    finally:
+        c.close()
+        s1.close()
+
+
+def test_udp_noop_handler_does_not_write_to_stdout(udp_server, capsys):
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.sendto(b"/nonexistent", ("127.0.0.1", udp_server.port))
+    sock.close()
+
+    captured = capsys.readouterr()
+    assert captured.out == ""
+
+
+def test_udp_send_rejects_closed():
+    udp = UDP("127.0.0.1", 0)
+    udp.close()
+    with pytest.raises(OSError):
+        udp.send(b"data", ("127.0.0.1", 9999))
+
+
+def test_udp_close_stops_recv_loop():
+    udp = UDP("127.0.0.1", 0)
+    udp.listen(lambda data, addr: None)
+    assert udp._recv_thread.is_alive()
+    udp.close()
+    assert udp._socket.fileno() == -1
+
+
+def test_udp_callback_exception_does_not_kill_loop():
+    udp = UDP("127.0.0.1", 0)
+    received = threading.Event()
+
+    def faulty_cb(data, addr):
+        try:
+            raise ValueError("simulated error")
+        finally:
+            received.set()
+
+    udp.listen(faulty_cb)
+    try:
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        sock.sendto(b"data", ("127.0.0.1", udp.port))
+        sock.close()
+
+        assert received.wait(timeout=1), "callback was never called"
+        assert udp._recv_thread.is_alive()
+    finally:
+        udp.close()
+
+
+def test_udp_close_idempotent():
+    udp = UDP("127.0.0.1", 0)
+    udp.close()
+    udp.close()
+
+
+def test_udp_listen_after_close():
+    udp = UDP("127.0.0.1", 0)
+    udp.close()
+    with pytest.raises(RuntimeError, match="endpoint is closed"):
+        udp.listen(lambda data, addr: None)
+
+
+def test_udp_context_manager():
+    with UDP("127.0.0.1", 0) as udp:
+        assert udp._socket.fileno() >= 0
+    assert udp._socket.fileno() == -1
+
+
+def test_udp_listen_idempotent():
+    udp = UDP("127.0.0.1", 0)
+    udp.listen(lambda data, addr: None)
+    thread = udp._recv_thread
+    udp.listen(lambda data, addr: None)
+    assert udp._recv_thread is thread
+    udp.close()
+
+
+def test_udp_listen_stops_on_close():
+    udp = UDP("127.0.0.1", 0)
+    received = threading.Event()
+
+    udp.listen(lambda data, addr: received.set())
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    sock.sendto(b"hello", ("127.0.0.1", udp.port))
+    sock.close()
+
+    assert received.wait(timeout=2), "handler was not called"
+
+    thread = udp._recv_thread
+    udp.close()
+    thread.join(timeout=1)
+    assert not thread.is_alive()


### PR DESCRIPTION
  ## 摘要

  新增 UDP 端点类，用于服务发现和广播。

  ## 变更

  - `src/connect_udp.py` — `send`/`broadcast`/`listen`/`close`
  - `test/test_udp.py`（14个测试，96%覆盖率）
  - `docs/Network_APIs/UDP_APIs.rst` — API文档 + 4个使用示例
  - `docs/Network_APIs/TCP_*.rst` — See Also 交叉引用

  ## 设计

  `bool` 关闭标志 + `settimeout(0.1)` 确保跨平台可关闭 + 双 try 块异常分离。